### PR TITLE
show remaining time until next reset

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -218,7 +218,7 @@ def mining_behaviour(tx1, ty1, tx2, ty2, mr_start, mr_end, ml_start, ml_end, rm_
         pyautogui.press('f2')
 
         # reset every 170 seconds (depends on mining barge)
-        set_next_reset(mining_reset)
+        set_next_reset(mining_reset, NEXT_RESET_IN)
         sleep_and_log(mining_reset)
         log("reset mining script...")
 
@@ -227,30 +227,46 @@ def mining_behaviour(tx1, ty1, tx2, ty2, mr_start, mr_end, ml_start, ml_end, rm_
             log("Done mining")
             break
 
-# Create a global variable to store the next reset time
-next_reset_time = 0
+# Constants for timers 
+TIME_LEFT = "Time left"
+NEXT_RESET_IN = "Next reset in"
+
+# Dictionary to store next reset time for each counter
+timers = {
+    TIME_LEFT: 0,
+    NEXT_RESET_IN: 0
+}
 
 # Function to update the countdown timer
-def update_timer(label):
-    global next_reset_time
-
+def update_timer(label, counter):
     # Calculate remaining time until the next reset
-    remaining_time = max(0, next_reset_time - time.time())
+    remaining_time = max(0, timers[counter] - time.time())
 
-    # Format remaining time as minutes and seconds
+    # Calculate days, hours, minutes, and seconds
+    days = int(remaining_time // (60 * 60 * 24))
+    remaining_time %= (60 * 60 * 24)
+    hours = int(remaining_time // (60 * 60))
+    remaining_time %= (60 * 60)
     minutes = int(remaining_time // 60)
     seconds = int(remaining_time % 60)
 
+    # Format the remaining time
+    remaining_str = ""
+    if days > 0:
+        remaining_str += f"{days}d "
+    if hours > 0:
+        remaining_str += f"{hours}h "
+    remaining_str += f"{minutes:02d}m {seconds:02d}s"
+
     # Update the label text with the remaining time
-    label.config(text=f"Next Reset in: {minutes:02d}:{seconds:02d}")
+    label.config(text=f"{counter}: {remaining_str}")
 
     # Schedule the update function to run again after 1 second
-    label.after(1000, update_timer, label)
+    label.after(1000, update_timer, label, counter)
 
-# Function to set the next reset time
-def set_next_reset(time_interval):
-    global next_reset_time
-    next_reset_time = time.time() + time_interval
+# Function to set the next reset time for a specific counter
+def set_next_reset(time_interval, counter):
+    timers[counter] = time.time() + time_interval
 
 def sleep_and_log(seconds):
     log(f"sleeping {seconds} seconds")

--- a/functions.py
+++ b/functions.py
@@ -218,6 +218,7 @@ def mining_behaviour(tx1, ty1, tx2, ty2, mr_start, mr_end, ml_start, ml_end, rm_
         pyautogui.press('f2')
 
         # reset every 170 seconds (depends on mining barge)
+        set_next_reset(mining_reset)
         sleep_and_log(mining_reset)
         log("reset mining script...")
 
@@ -225,6 +226,31 @@ def mining_behaviour(tx1, ty1, tx2, ty2, mr_start, mr_end, ml_start, ml_end, rm_
         if elapsed_time >= mining_loop:
             log("Done mining")
             break
+
+# Create a global variable to store the next reset time
+next_reset_time = 0
+
+# Function to update the countdown timer
+def update_timer(label):
+    global next_reset_time
+
+    # Calculate remaining time until the next reset
+    remaining_time = max(0, next_reset_time - time.time())
+
+    # Format remaining time as minutes and seconds
+    minutes = int(remaining_time // 60)
+    seconds = int(remaining_time % 60)
+
+    # Update the label text with the remaining time
+    label.config(text=f"Next Reset in: {minutes:02d}:{seconds:02d}")
+
+    # Schedule the update function to run again after 1 second
+    label.after(1000, update_timer, label)
+
+# Function to set the next reset time
+def set_next_reset(time_interval):
+    global next_reset_time
+    next_reset_time = time.time() + time_interval
 
 def sleep_and_log(seconds):
     log(f"sleeping {seconds} seconds")

--- a/main.py
+++ b/main.py
@@ -42,6 +42,7 @@ def start_function():
 
 def repeat_function(minutes, undock_coo_value, mining_coo_values, warp_to_coo_values, docking_coo_values, clear_cargo_coo_values, target_one_coo_values, target_two_coo_values, mouse_reset_coo_value, mining_hold_value, mining_yield_value):
     fe.log(f"The mining script will run {minutes} minutes!")
+    fe.set_next_reset(minutes * 60, fe.TIME_LEFT)
     end_time = time.time() + (minutes * 60)
 
     # cargo loading phrase
@@ -283,14 +284,14 @@ class POINT(ctypes.Structure):
 
 # Create a label to display the mouse position
 mouse_position_label = tk.Label(root, text="")
-mouse_position_label.pack(pady=20)
+mouse_position_label.pack(pady=10)
 
 bold_font = tkFont.Font(weight="bold")
 
 # Function to update the mouse position
 def update_mouse_position():
     x, y = get_mouse_position()
-    mouse_position_label.config(text=f"Mouse-Position: {x}, {y}", fg="red", font=bold_font)
+    mouse_position_label.config(text=f"Mouse-Position: {x}, {y}", font=("Arial", 12))
     mouse_position_label.after(100, update_mouse_position)
 
 # Start update mouse position
@@ -301,12 +302,17 @@ root.iconbitmap('')
 
 root.bind("<Control-i>", insert_mouse_position)
 
+total_time_label = tk.Label(root, text="", font=("Arial", 12))
+total_time_label.pack(pady=10)
+
+fe.update_timer(total_time_label, fe.TIME_LEFT)
+
 # Create a label to display the countdown timer
-timer_label = tk.Label(root, text="", font=("Arial", 12))
-timer_label.pack(pady=10)
+next_reset_label = tk.Label(root, text="", font=("Arial", 12))
+next_reset_label.pack(pady=10)
 
 # Start updating the countdown timer
-fe.update_timer(timer_label)
+fe.update_timer(next_reset_label, fe.NEXT_RESET_IN)
 
 # Start Tkinter Window
 root.mainloop()

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ def start_function():
     target_two_coo_values = [int(x.strip()) for x in config['POSITIONS']['target_two_coo'].split(",")]
     mouse_reset_coo_value = [int(x.strip()) for x in config['POSITIONS']['mouse_reset_coo'].split(",")]
     mining_hold_value = int(config['SETTINGS']['mining_hold'])
-    mining_yield_value = int(config['SETTINGS']['mining_yield'])
+    mining_yield_value = float(config['SETTINGS']['mining_yield'].replace(',', '.'))
     thread = threading.Thread(target=repeat_function, args=(minutes, undock_coo_value, mining_coo_values, warp_to_coo_values, docking_coo_values, clear_cargo_coo_values, target_one_coo_values, target_two_coo_values, mouse_reset_coo_value, mining_hold_value, mining_yield_value))
     thread.start()
 
@@ -300,6 +300,13 @@ update_mouse_position()
 root.iconbitmap('')
 
 root.bind("<Control-i>", insert_mouse_position)
+
+# Create a label to display the countdown timer
+timer_label = tk.Label(root, text="", font=("Arial", 12))
+timer_label.pack(pady=10)
+
+# Start updating the countdown timer
+fe.update_timer(timer_label)
 
 # Start Tkinter Window
 root.mainloop()


### PR DESCRIPTION
fixes #12 

see https://github.com/x-actly/Eve-Online-Mining-Bot/issues/12#issuecomment-2090459213 for screenshot

also fixes parsing of yield for wierd norwegians with comma as decimal separator  :D 

also now shows remaining run time

![image](https://github.com/x-actly/Eve-Online-Mining-Bot/assets/404102/83f4bf9f-cb64-458b-a402-87c797c33449)

- [ ] configurable hardener combo
- [ ] supply number of runs instead of wanted total runtime
- [ ] remove 0.9 factor for cargo hold time calculation 

Currently testing the three things above locally
