### PR TITLE
decrease time sleeping, make actions faster, select eve window and focus eve window before actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+pyenv

--- a/functions.py
+++ b/functions.py
@@ -1,91 +1,77 @@
 from tkinter import Label
 import time, datetime, random
 import pyautogui
+from typing import Callable
 
+
+# Constants
 ########################################################
 
-def undock(x, y):
+long_sleep_base = 70
+short_sleep_base = 12
 
-    random_time = random.uniform(1,2)
+# Functions
+########################################################
+
+def undock(x: int, y: int):
     log("undocking...")
     # undock
-    pyautogui.moveTo(x,y, duration=random_time)
+    time = random.uniform(1,2)
+    pyautogui.moveTo(x,y, duration=time)
     pyautogui.mouseDown(button='left')
-    sleep_and_log(random_time)
+    sleep_and_log(time)
     pyautogui.mouseUp(button='left')
     sleep_small()
 
-def set_hardener_online(key_combo):
-
+def set_hardener_online(key_combo: str):
     log("starting hardener...")
     # set hardener online
     translate_key_combo(key_combo)
 
-def warp_to_pos_dropdown(x, y,rm_x, rm_y):
-
-    random_time = random.uniform(2,3)
-    log("warping to position...")
-    # warping to belt
-    sleep_and_log(10)
-    pyautogui.moveTo(x,y, 2)
-    pyautogui.click(button='right')
-    sleep_and_log(random_time)
-    pyautogui.moveRel(rm_x, rm_y)
-    sleep_and_log(random_time)
-    pyautogui.click(button='left')
-    sleep_long()
-
-def click_circle_menu(x, y, x_offset, y_offset):
-    random_time = random.uniform(6, 7)
+def click_circle_menu(x: int, y: int, x_offset: int, y_offset: int):
     log("clicking on the circle menu...")
-    for _ in range(1):
-        sleep_and_log(random_time)
-        pyautogui.moveTo(x, y)
-        pyautogui.mouseDown()
-        sleep_and_log(random_time)
-        pyautogui.moveRel(x_offset, y_offset, 1)
-        pyautogui.mouseUp()
+    pyautogui.moveTo(x, y)
+    pyautogui.mouseDown()
+    sleep_and_log(0.5)
+    pyautogui.moveRel(x_offset, y_offset, 1)
+    pyautogui.mouseUp()
     sleep_long()
 
-def click_warp_circle_menu(x, y):
+def click_warp_circle_menu(x: int, y: int):
     x_offset = -50
     y_offset = random.randint(-51, -49)
     click_circle_menu(x, y, x_offset, y_offset)
 
-def click_dock_circle_menu(x, y):
+def click_dock_circle_menu(x: int, y: int):
     x_offset = 0
     y_offset = random.randint(-51, -49)
     click_circle_menu(x, y, x_offset, y_offset)
     # sleep longer when clicking the docking button in the circle menu
-    sleep_long()
+    sleep_and_log(30)
 
-def drone_out(x,y):
-
-    random_time = random.uniform(1,2)
+def drone_out(x: int, y: int):
     log("launching drones...")
     # drone out, random click in space
-    pyautogui.click(x, y, button='left', duration=random_time)
+    pyautogui.click(x, y, button='left', duration=random.uniform(1,2))
     # drone out
-    sleep_and_log(5)
+    sleep_and_log(3)
     pyautogui.keyDown('shift')
     pyautogui.press('f')
-    sleep_and_log(1)
+    sleep_and_log(0.5)
     # Umschalt loslassen
     pyautogui.keyUp('shift')
 
 def drone_in():
-
     log("drones returning to bay...")
     # drone in
     pyautogui.keyDown('shift')
     pyautogui.press('r')
-    sleep_and_log(1)
+    sleep_and_log(0.5)
     pyautogui.keyUp('shift')
     # drone time back to ship
     sleep_small()
 
-def clear_cargo(x, y):
-
+def clear_cargo(x: int, y: int):
     random_time = random.uniform(3, 4)
     log("clearing cargo...")
     # clear cargo
@@ -106,10 +92,9 @@ def mining_behaviour(tx1: int, ty1: int,
                      mr_start: int, mr_end: int, 
                      ml_start: float, ml_end: float, 
                      rm_x: int, rm_y: int, 
-                     unlock_all_targets_keys: str):
-
-    random_time = random.uniform(3, 4)
-    
+                     unlock_all_targets_keys: str,
+                     focus_eve_window: Callable):
+     
     # start time to counter looptime
     start_time = time.time()
 
@@ -120,6 +105,7 @@ def mining_behaviour(tx1: int, ty1: int,
     mining_loop = random.uniform(ml_start, ml_end)
     
     while True:
+        focus_eve_window()
         if unlock_all_targets_keys:
             # reset mouse assigned mining laser random in space
             pyautogui.moveTo(rm_x, rm_y)
@@ -128,7 +114,7 @@ def mining_behaviour(tx1: int, ty1: int,
             [pyautogui.keyDown(key) for key in unlock_all_targets_keys.split('-')]
             time.sleep(0.5)
             [pyautogui.keyUp(key) for key in unlock_all_targets_keys.split('-')]
-            sleep_and_log(3)
+            sleep_and_log(0.5)
         else:
             log("Manually unlocking targets 1 and 2")
             # reset target 1
@@ -139,7 +125,7 @@ def mining_behaviour(tx1: int, ty1: int,
             pyautogui.keyUp('ctrl')
             pyautogui.keyUp('shift')
 
-            sleep_and_log(3)
+            sleep_and_log(0.5)
 
             # reset target 2
             pyautogui.moveTo(tx2, ty2)
@@ -151,21 +137,21 @@ def mining_behaviour(tx1: int, ty1: int,
 
         # reset mininglaser 1
         pyautogui.keyDown('f1')
-        sleep_and_log(random_time)
+        sleep_and_log(0.5)
         pyautogui.keyUp('f1')
 
-        sleep_and_log(3)
+        sleep_and_log(1)
 
         # reset mininglaser 2
         pyautogui.keyDown('f2')
-        sleep_and_log(random_time)
+        sleep_and_log(0.5)
         pyautogui.keyUp('f2')
 
         # reset mouse assigned mining laser random in space
         pyautogui.moveTo(rm_x, rm_y)
         pyautogui.click(button='right')
 
-        sleep_and_log(2)
+        sleep_and_log(0.5)
 
         # console
         log("mining...")
@@ -176,9 +162,10 @@ def mining_behaviour(tx1: int, ty1: int,
         pyautogui.click(button='left')
         pyautogui.keyUp('ctrl')
         sleep_and_log(3)
+        focus_eve_window()
         pyautogui.press('f1')
 
-        sleep_and_log(5)
+        sleep_and_log(0.5)
 
         # target 2
         pyautogui.moveTo(tx2,ty2)
@@ -186,6 +173,7 @@ def mining_behaviour(tx1: int, ty1: int,
         pyautogui.click(button='left')
         pyautogui.keyUp('ctrl')
         sleep_and_log(3)
+        focus_eve_window()
         # second left click to focus the second target
         pyautogui.click(button='left')
         pyautogui.press('f2')
@@ -260,7 +248,7 @@ def log(msg: str):
     print(f"[{timestamp}] - {msg}")
 
 def sleep_long():
-    sleep_and_log(random.uniform(70, 75))
+    sleep_and_log(random.uniform(long_sleep_base, long_sleep_base + 5))
 
 def sleep_small():
-    sleep_and_log(random.uniform(12, 15))
+    sleep_and_log(random.uniform(short_sleep_base, short_sleep_base + 3))

--- a/main.py
+++ b/main.py
@@ -8,6 +8,8 @@ from ctypes import windll
 import functions as fe
 import os
 import configparser
+import pygetwindow as gw
+import re
 
 # Check if the file exists
 if not os.path.isfile('config.properties'):
@@ -17,12 +19,20 @@ if not os.path.isfile('config.properties'):
 config = configparser.ConfigParser()
 config.read('config.properties')
 
+# a developer hatch/hook for now, if set to False things will surely break.
+disable_if_no_eve_windows = bool(config['SETTINGS'].get('disable_if_no_eve_windows', "True"))
+
+# When cargo hold is full, the ship will dock up and unload cargo, undock and warp to another belt
+cargo_loading_time_adjustment = int(config['SETTINGS'].get('cargo_loading_time_adjustment', "180"))
+
 # Mining functions
 #########################################################
 
 def start_function():
     global stop_flag
     stop_flag = False
+    # make sure we save and update config before we start
+    save_properties()
     mining_runs = int(entry.get())
     undock_coo_value = [int(x.strip()) for x in config['POSITIONS']['undock_coo'].split(",")]
     mining_coo_values = [(int(x.strip()), int(y.strip())) for x, y in (value.split(",") for value in config['POSITIONS']['mining_coo'].split("\n"))]
@@ -33,7 +43,12 @@ def start_function():
     mouse_reset_coo_values = [int(x.strip()) for x in config['POSITIONS']['mouse_reset_coo'].split(",")]
     mining_hold_value = int(config['SETTINGS']['mining_hold'])
     mining_yield_value = float(config['SETTINGS']['mining_yield'].replace(',', '.'))
+    # add 2 seconds to mining_reset_timer to ensure sure we wait long enough for the lasers to complete its mining cycle
+    mining_reset_timer = 2 + int(config['SETTINGS'].get('mining_reset_timer', "120"))
+    fe.log(f"Using miner reset timer of {mining_reset_timer} seconds.")
     cargo_loading_time =  mining_hold_value / mining_yield_value
+    if cargo_loading_time < fe.long_sleep_base:
+        fe.log("MINING HOLD OR YIELD IS LIKELY MISCONFIGURED, BECAUSE THE TOTAL TIME TO COMPLETE CARGO LOADING IS LESS THAN THE TIME TO WARP OUT TO BELT.")
     hardener_key = config['SETTINGS'].get('hardener_key', "F3")
     unlock_all_targets_key = config['SETTINGS'].get('unlock_all_targets_key', "")
     fe.log(f"The mining script will run {mining_runs} mining runs!")
@@ -46,6 +61,7 @@ def start_function():
         target_one_coo_values = target_one_coo_values, 
         target_two_coo_values = target_two_coo_values, 
         mouse_reset_coo_values = mouse_reset_coo_values, 
+        mining_reset_timer = mining_reset_timer,
         cargo_loading_time = cargo_loading_time, 
         hardener_key = hardener_key, 
         unlock_all_targets_key = unlock_all_targets_key
@@ -60,35 +76,42 @@ def repeat_function(mining_runs: int,
                     target_one_coo_values: list[int], 
                     target_two_coo_values: list[int], 
                     mouse_reset_coo_values: list[int], 
+                    mining_reset_timer: int,
                     cargo_loading_time: float, 
                     hardener_key: str, 
                     unlock_all_targets_key: str):
     disable_fields()
     actual_mining_runs = 0
     update_mining_runs(actual_mining_runs, mining_runs)
-    total_run_time = mining_runs * cargo_loading_time
-    fe.set_next_reset(total_run_time, fe.TIME_LEFT)
-    fe.log(f"Estimate for completion is {total_run_time / 60} minutes!")
+    estimated_run_time = mining_runs * (cargo_loading_time + (cargo_loading_time_adjustment if mining_runs > 1 else 0))
+    fe.set_next_reset(estimated_run_time, fe.TIME_LEFT)
+    fe.log(f"Estimate for completion is {estimated_run_time / 60} minutes!")
     while not stop_flag and actual_mining_runs < mining_runs:
+        selected_eve_window.activate()
         fe.set_next_reset(cargo_loading_time, fe.CARGO_LOAD_TIME)
         fe.log(f"The mining cargo is filled in about {cargo_loading_time / 60} minutes!")
         time.sleep(1)
         fe.undock(undock_coo_value[0], undock_coo_value[1])
+        selected_eve_window.activate()
         fe.set_hardener_online(hardener_key)
         item = random.choice(mining_coo_values)
         fe.click_warp_circle_menu(item[0], item[1])
+        selected_eve_window.activate()
         fe.drone_out(mouse_reset_coo_values[0], mouse_reset_coo_values[1])
         fe.mining_behaviour(
             tx1 = target_one_coo_values[0], ty1 = target_one_coo_values[1], 
             tx2 = target_two_coo_values[0], ty2 = target_two_coo_values[1], 
-            # maybe remove these and inline into mining_behaviour?
-            mr_start = 250, mr_end = 260, 
+            mr_start = mining_reset_timer, mr_end = mining_reset_timer, 
             ml_start = cargo_loading_time, ml_end = cargo_loading_time,
             rm_x = mouse_reset_coo_values[0], rm_y = mouse_reset_coo_values[1],
-            unlock_all_targets_keys = unlock_all_targets_key
+            unlock_all_targets_keys = unlock_all_targets_key,
+            focus_eve_window = lambda: selected_eve_window.activate()
         )
+        selected_eve_window.activate()
         fe.drone_in()
+        selected_eve_window.activate()
         fe.click_dock_circle_menu(warp_to_coo_values[0], warp_to_coo_values[1])
+        selected_eve_window.activate()
         fe.clear_cargo(clear_cargo_coo_values[0], clear_cargo_coo_values[1])
         actual_mining_runs += 1
         update_mining_runs(actual_mining_runs, mining_runs)
@@ -99,7 +122,7 @@ def repeat_function(mining_runs: int,
 def stop_function():
     global stop_flag
     fe.set_next_reset(0, fe.TIME_LEFT)
-    print("The mining script ends with this run!")
+    fe.log("The mining script ends with this run!")
     stop_flag = True
 #########################################################
 
@@ -154,8 +177,15 @@ stop_flag = False
 
 # Create Tkinter window
 root = tk.Tk()
+root.wm_attributes("-topmost", 1)
 root.title("Mining Bot Owl-Edition")
-root.geometry("480x640")  # Set windows size
+screen_width = root.winfo_screenwidth()
+screen_height = root.winfo_screenheight()
+window_width = 480
+window_height = 680
+x_pos = screen_width - window_width
+y_pos = 0
+root.geometry(f"{window_width}x{window_height}+{x_pos}+{y_pos}")
 
 # Make window not resizable
 root.resizable(False, True)
@@ -168,14 +198,58 @@ input_frame.pack(pady=10)
 button_frame = tk.Frame(root)
 button_frame.pack(pady=10)
 
+# EVE window selection 
+#########################################################
+
+def on_window_select(selection):
+    global selected_eve_window
+    windows = gw.getWindowsWithTitle(selection)
+    if windows:
+        selected_eve_window = windows[0]
+
+# Label for the EVE window selector
+window_label = tk.Label(input_frame, text="Select EVE window:")
+window_label.grid(row=0, column=0, sticky="w")
+
+# Get list of EVE windows
+eve_windows = gw.getWindowsWithTitle("EVE -")
+if eve_windows:
+    window_titles = [window.title for window in eve_windows]
+else:
+    window_titles = ["No EVE windows"]
+
+# Dropdown menu
+# Default selection
+eve_window = tk.StringVar()
+if window_titles:
+    eve_window.set(window_titles[0])
+    selected_eve_window = eve_windows[0]
+    fe.log(f"Selected the first EVE window")
+else:
+    eve_window.set("No EVE windows")
+
+# Function to update the OptionMenu text
+def update_option_menu(selection):
+    if selection:
+        eve_window.set(re.sub(r'EVE - .*', 'EVE - REDACTED', selection))
+    else:
+        eve_window.set("No EVE windows")
+
+window_select = tk.OptionMenu(input_frame, eve_window, *window_titles, command=on_window_select)
+update_option_menu(eve_window.get())  # Update initial text
+eve_window.trace_add('write', lambda *args: update_option_menu(eve_window.get()))  # Update text on selection change
+window_select.grid(row=0, column=1, padx=5, pady=4, sticky="w")
+
 # Mining time
 #########################################################
 
-# Create input field for bot duration in minutes
+# Label for the number of mining runs
 entry_label = tk.Label(input_frame, text="Set number of mining runs:")
-entry_label.grid(row=0, column=0, sticky="w")
+entry_label.grid(row=1, column=0, sticky="w")
+
+# Entry field for the number of mining runs
 entry = tk.Entry(input_frame)
-entry.grid(row=0, column=1, padx=5, pady=4, sticky="w")
+entry.grid(row=1, column=1, padx=5, pady=4, sticky="w")
 entry.insert(tk.END, config['SETTINGS']['mining_runs'])
 
 # Undock
@@ -183,9 +257,9 @@ entry.insert(tk.END, config['SETTINGS']['mining_runs'])
 
 # create input field for undock coordinates
 undock_coo_label = tk.Label(input_frame, text="Undock-Button Position:")
-undock_coo_label.grid(row=1, column=0, sticky="w")
+undock_coo_label.grid(row=2, column=0, sticky="w")
 undock_coo_entry = tk.Entry(input_frame)
-undock_coo_entry.grid(row=1, column=1, padx=5, pady=4, sticky="w")
+undock_coo_entry.grid(row=2, column=1, padx=5, pady=4, sticky="w")
 undock_coo_entry.insert(tk.END, config['POSITIONS']['undock_coo'])
 
 # Clear Cargo Position
@@ -193,9 +267,9 @@ undock_coo_entry.insert(tk.END, config['POSITIONS']['undock_coo'])
 
 # Create input field for clear-cargo position
 clear_cargo_coo_label = tk.Label(input_frame, text="Clear-Cargo Position:")
-clear_cargo_coo_label.grid(row=2, column=0, sticky="w")
+clear_cargo_coo_label.grid(row=3, column=0, sticky="w")
 clear_cargo_coo_entry = tk.Entry(input_frame)
-clear_cargo_coo_entry.grid(row=2, column=1, padx=5, pady=4, sticky="w")
+clear_cargo_coo_entry.grid(row=3, column=1, padx=5, pady=4, sticky="w")
 clear_cargo_coo_entry.insert(tk.END, config['POSITIONS']['clear_cargo_coo'])
 
 # check if the coordinate is set correctly
@@ -216,16 +290,16 @@ def check_function():
     thread.start()
 
 check_button = tk.Button(input_frame, text="Test", compound="left", command=check_function)
-check_button.grid(row=2, column=2, padx=5, pady=4, sticky="w")
+check_button.grid(row=3, column=2, padx=5, pady=4, sticky="w")
 
 # Mining Hold
 #########################################################
 
 # Create input field for mining hold in m3
 mining_hold_label = tk.Label(input_frame, text="Mining Hold (m3):")
-mining_hold_label.grid(row=3, column=0, sticky="w")
+mining_hold_label.grid(row=4, column=0, sticky="w")
 mining_hold_entry = tk.Entry(input_frame)
-mining_hold_entry.grid(row=3, column=1, padx=5, pady=4, sticky="w")
+mining_hold_entry.grid(row=4, column=1, padx=5, pady=4, sticky="w")
 mining_hold_entry.insert(tk.END, config['SETTINGS']['mining_hold'])
 
 # Mining Yield
@@ -233,9 +307,9 @@ mining_hold_entry.insert(tk.END, config['SETTINGS']['mining_hold'])
 
 # Create input field for mining yield in m3/s
 mining_yield_label = tk.Label(input_frame, text="Mining Yield (m3/s):")
-mining_yield_label.grid(row=4, column=0, sticky="w")
+mining_yield_label.grid(row=5, column=0, sticky="w")
 mining_yield_entry = tk.Entry(input_frame)
-mining_yield_entry.grid(row=4, column=1, padx=5, pady=4, sticky="w")
+mining_yield_entry.grid(row=5, column=1, padx=5, pady=4, sticky="w")
 mining_yield_entry.insert(tk.END, config['SETTINGS']['mining_yield'])
 
 # Target-One-Position
@@ -293,6 +367,8 @@ mining_coo_entry.insert(tk.END, config['POSITIONS']['mining_coo'].lstrip('\n'))
 # Create start button
 start_button = tk.Button(button_frame, text="Start", command=start_function)
 start_button.grid(row=0, column=0, padx=(0, 10), pady=10, ipadx=5)
+if disable_if_no_eve_windows and not eve_windows:
+    start_button.config(state=tk.DISABLED)
 
 # Create stop button
 stop_button = tk.Button(button_frame, text="Stop", command=stop_function)
@@ -311,10 +387,10 @@ def save_properties():
     config['POSITIONS']['target_two_coo'] = target_two_coo_entry.get()
     config['POSITIONS']['mouse_reset_coo'] = mouse_reset_coo_entry.get()
     config['POSITIONS']['warp_to_coo'] = warp_to_coo_entry.get()
-    config['POSITIONS']['mining_coo'] = mining_coo_entry.get(1.0, tk.END)
+    config['POSITIONS']['mining_coo'] = mining_coo_entry.get(1.0, tk.END).strip()
     with open('config.properties', 'w') as configfile:
         config.write(configfile)
-    print("values saved!")
+    fe.log("values saved!")
 
 save_button = tk.Button(button_frame, text="Save", command=save_properties)
 save_button.grid(row=0, column=2, padx=(20, 0), pady=10, ipadx=5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ keyboard
 datetime
 pyautogui
 Pillow
+pygetwindow


### PR DESCRIPTION
and make estimated time more correctly represent time remaining
force window to always be on top of other windows, making it possible to use the computer ...

fixes #26 (by allowing to configure miner_duration in settings to either 60 or 180, there is only two, default is 60s. by having this shorter sleep before reset, we avoid hanging for a long time before docking after a reset. previous sleep was 250s)
fixes #40 (see above)
fixes #39 
fixes #41 
fixes #32 (selecting window by title and using window reference)
fixes #31 
partially implementing #36 (keeping the window on top, not changing ui)