### PR TITLE
add automatic screenshot at end of mining run, before undocking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 pyenv
 *.log
+*.png

--- a/config.py
+++ b/config.py
@@ -23,6 +23,9 @@ class ConfigHandler:
 
     def get_disable_if_no_eve_windows(self):
         return self._get_boolean_setting("disable_if_no_eve_windows", True)
+    
+    def get_take_screenshots(self):
+        return self._get_boolean_setting("take_screenshots", False)
 
     def get_cargo_loading_time_adjustment(self):
         return self._get_setting(
@@ -76,15 +79,6 @@ class ConfigHandler:
 
     def set_hardener_key(self, value):
         self._set_setting("hardener_key", value)
-
-    def set_unlock_all_targets_key(self, value):
-        self._set_setting("unlock_all_targets_key", value)
-
-    def set_disable_if_no_eve_windows(self, value):
-        self._set_setting("disable_if_no_eve_windows", str(value))
-
-    def set_cargo_loading_time_adjustment(self, value):
-        self._set_setting("cargo_loading_time_adjustment", str(value))
 
     def set_warp_to_coo(self, value):
         self._set_position("warp_to_coo", value)

--- a/functions.py
+++ b/functions.py
@@ -139,7 +139,7 @@ def mining_behaviour(
         if unlock_all_targets_keys:
             # reset mouse assigned mining laser random in space
             pyautogui.moveTo(rm_x, rm_y)
-            pyautogui.click(button="right")
+            pyautogui.click(button="left")
             logger.info(f"Using unlock all targets key: {unlock_all_targets_keys}")
             [pyautogui.keyDown(key) for key in unlock_all_targets_keys.split("-")]
             time.sleep(0.5)

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import functions as fe
 from config import ConfigHandler
 import re
 from loguru import logger
+from datetime import datetime
 
 log_level = "TRACE"
 log_format = "[{time}] [{level}] {name}:{function}:{line} - {message}"
@@ -31,6 +32,9 @@ disable_if_no_eve_windows = config.get_disable_if_no_eve_windows()
 
 # When cargo hold is full, the ship will dock up and unload cargo, undock and warp to another belt
 cargo_loading_time_adjustment = config.get_cargo_loading_time_adjustment()
+
+# take screenshots after clearing cargo
+take_screenshots = config.get_take_screenshots()
 
 # Mining functions
 #########################################################
@@ -153,6 +157,9 @@ def repeat_function(
         fe.clear_cargo(clear_cargo_coo_values[0], clear_cargo_coo_values[1])
         actual_mining_runs += 1
         update_mining_runs(actual_mining_runs, mining_runs)
+        if take_screenshots:
+            img = pyautogui.screenshot()
+            img.save(f"eve_screenshot_{datetime.now().strftime("%d-%m-%Y-%H-%M-%S")}.png")
     logger.info(f"Completed {actual_mining_runs}/{mining_runs} mining sessions")
     enable_fields()
 


### PR DESCRIPTION
partially fixes #46
useful to catch position bugs when clearing cargo and can also be checked on other machine if code is running from dropbox folder
on macOS this will ask for permission to do so and will likely hang the program when doing so
Havent tested on Windows yet (still using the current version and its killing those roids...)

enable screenshots with 

````'
[SETTINGS]
take_screenshots = True
````