### PR TITLE
safer auto dock on panic and after mining run

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -4,32 +4,20 @@ import pyautogui
 from typing import Callable
 from loguru import logger
 
-# Constants
-########################################################
-
-long_sleep_base = 70
-short_sleep_base = 12
-
 
 # Functions
 ########################################################
-def long_interval():
-    return random.uniform(long_sleep_base, long_sleep_base + 5)
 
 
-def small_interval():
-    return random.uniform(short_sleep_base, short_sleep_base + 5)
-
-
-def undock(x: int, y: int, sleep: int = small_interval()):
+def undock(x: int, y: int):
     logger.info("undocking...")
     # undock
     time = random.uniform(1, 2)
     pyautogui.moveTo(x, y, duration=time)
     pyautogui.mouseDown(button="left")
-    sleep_and_log(time)
+    sleep_and_log(0.5)
     pyautogui.mouseUp(button="left")
-    sleep_and_log(sleep)
+    sleep_and_log(0.5)
 
 
 def set_hardener_online(key_combos: list[str]):
@@ -40,32 +28,26 @@ def set_hardener_online(key_combos: list[str]):
         time.sleep(0.5)
 
 
-def click_circle_menu(
-    x: int, y: int, x_offset: int, y_offset: int, sleep: int = long_interval()
-):
+def click_circle_menu(x: int, y: int, x_offset: int, y_offset: int):
     logger.info("clicking on the circle menu...")
     pyautogui.moveTo(x, y)
     pyautogui.mouseDown()
     sleep_and_log(0.5)
     pyautogui.moveRel(x_offset, y_offset, 1)
     pyautogui.mouseUp()
-    sleep_and_log(sleep)
+    sleep_and_log(0.5)
 
 
-def click_warp_circle_menu(x: int, y: int):
+def click_top_left_circle_menu(x: int, y: int):
     x_offset = -50
     y_offset = random.randint(-51, -49)
     click_circle_menu(x, y, x_offset, y_offset)
 
 
-def click_dock_circle_menu(
-    x: int, y: int, menu_sleep: int = long_interval(), sleep: int = 30
-):
+def click_top_center_circle_menu(x: int, y: int):
     x_offset = 0
     y_offset = random.randint(-51, -49)
-    click_circle_menu(x, y, x_offset, y_offset, sleep=menu_sleep)
-    # sleep longer when clicking the docking button in the circle menu
-    sleep_and_log(sleep)
+    click_circle_menu(x, y, x_offset, y_offset)
 
 
 def drone_out(x: int, y: int):
@@ -81,15 +63,13 @@ def drone_out(x: int, y: int):
     pyautogui.keyUp("shift")
 
 
-def drone_in(sleep: int = small_interval()):
+def drone_in():
     logger.info("drones returning to bay...")
     # drone in
     pyautogui.keyDown("shift")
     pyautogui.press("r")
     sleep_and_log(0.5)
     pyautogui.keyUp("shift")
-    # drone time back to ship
-    sleep_and_log(sleep)
 
 
 def clear_cargo(x: int, y: int):
@@ -115,10 +95,8 @@ def mining_behaviour(
     ty1: int,
     tx2: int,
     ty2: int,
-    mr_start: int,
-    mr_end: int,
-    ml_start: float,
-    ml_end: float,
+    mining_reset: int,
+    mining_loop: float,
     rm_x: int,
     rm_y: int,
     unlock_all_targets_keys: str,
@@ -127,12 +105,6 @@ def mining_behaviour(
 
     # start time to counter looptime
     start_time = time.time()
-
-    #  periodically reset interval while mining - mr_start = 250, mr_end = 260
-    mining_reset = random.uniform(mr_start, mr_end)
-
-    #  periodically break while loop - ml_start = 2500, ml_end = 2600
-    mining_loop = random.uniform(ml_start, ml_end)
 
     while True:
         focus_eve_window()

--- a/functions.py
+++ b/functions.py
@@ -244,5 +244,6 @@ def set_next_reset(time_interval: float, counter: str):
 
 
 def sleep_and_log(seconds: float):
+    seconds = seconds + random.uniform(0, 1)
     logger.trace("sleeping {} seconds", seconds)
     time.sleep(seconds)

--- a/functions.py
+++ b/functions.py
@@ -100,14 +100,14 @@ def mining_behaviour(
     rm_x: int,
     rm_y: int,
     unlock_all_targets_keys: str,
-    focus_eve_window: Callable,
+    activate_eve_window: Callable,
 ):
 
     # start time to counter looptime
     start_time = time.time()
 
     while True:
-        focus_eve_window()
+        activate_eve_window()
         if unlock_all_targets_keys:
             # reset mouse assigned mining laser random in space
             pyautogui.moveTo(rm_x, rm_y)
@@ -164,7 +164,7 @@ def mining_behaviour(
         pyautogui.click(button="left")
         pyautogui.keyUp("ctrl")
         sleep_and_log(3)
-        focus_eve_window()
+        activate_eve_window()
         pyautogui.press("f1")
 
         sleep_and_log(0.5)
@@ -175,7 +175,7 @@ def mining_behaviour(
         pyautogui.click(button="left")
         pyautogui.keyUp("ctrl")
         sleep_and_log(3)
-        focus_eve_window()
+        activate_eve_window()
         # second left click to focus the second target
         pyautogui.click(button="left")
         pyautogui.press("f2")

--- a/main.py
+++ b/main.py
@@ -132,7 +132,7 @@ def repeat_function(cargo_loading_time: float):
         if take_screenshots:
             img = pyautogui.screenshot()
             img.save(
-                f"eve_screenshot_{datetime.now().strftime("%d-%m-%Y-%H-%M-%S")}.png"
+                f'eve_screenshot_{datetime.now().strftime("%d-%m-%Y-%H-%M-%S")}.png'
             )
     logger.info(
         f"Completed {actual_mining_runs}/{config.get_mining_runs()} mining sessions"

--- a/main.py
+++ b/main.py
@@ -76,7 +76,8 @@ def start_function():
         cargo_loading_time=cargo_loading_time,
         cargo_loading_time_adjustment=cargo_loading_time_adjustment,
     )
-    logger.info(f"Estimate for completion is {estimated_run_time / 60} minutes!")
+    estimated_run_time_str = fe.get_remaining_time(estimated_run_time)
+    logger.info(f"Estimate for completion is {estimated_run_time_str}")
     thread = threading.Thread(
         target=lambda: repeat_function(cargo_loading_time=cargo_loading_time)
     )
@@ -91,8 +92,8 @@ def repeat_function(cargo_loading_time: float):
     while not stop_flag and actual_mining_runs < mining_runs:
         activate_eve_window()
         fe.set_next_reset(cargo_loading_time, fe.CARGO_LOAD_TIME)
-        loaded_minutes = cargo_loading_time / 60
-        logger.info(f"The mining cargo is filled in about {loaded_minutes} minutes!")
+        loaded_in_str = fe.get_remaining_time(cargo_loading_time)
+        logger.info(f"The mining cargo is filled in about {loaded_in_str}")
         time.sleep(1)
         undock_x, undock_y = config.get_undock_coo()
         fe.undock(x=undock_x, y=undock_y)

--- a/main.py
+++ b/main.py
@@ -33,6 +33,12 @@ cargo_loading_time_adjustment = config.get_cargo_loading_time_adjustment()
 # take screenshots after clearing cargo
 take_screenshots = config.get_take_screenshots()
 
+# CONSTANTS
+
+SMALL_SLEEP = 12
+MEDIUM_SLEEP = 70
+LONG_SLEEP = 100
+
 # Mining functions
 #########################################################
 
@@ -49,7 +55,7 @@ def get_cargo_loading_time(mining_hold: int, mining_yield: float):
     if mining_hold == 0:
         return 0
     time = mining_hold / mining_yield if mining_yield > 0 else 0
-    if time < 100:
+    if time < LONG_SLEEP:
         logger.error(
             "MINING HOLD OR YIELD IS LIKELY MISCONFIGURED, BECAUSE THE TOTAL TIME TO COMPLETE CARGO LOADING IS LESS THAN THE TIME TO WARP OUT TO BELT."
         )
@@ -90,11 +96,11 @@ def repeat_function(cargo_loading_time: float):
         time.sleep(1)
         undock_x, undock_y = config.get_undock_coo()
         fe.undock(x=undock_x, y=undock_y)
-        fe.sleep_and_log(10)
+        fe.sleep_and_log(SMALL_SLEEP)
         fe.set_hardener_online(config.get_hardener_keys())
         item = random.choice(config.get_mining_coo())
         fe.click_top_left_circle_menu(item[0], item[1])
-        fe.sleep_and_log(75)
+        fe.sleep_and_log(MEDIUM_SLEEP)
         rm_x, rm_y = config.get_mouse_reset_coo()
         fe.drone_out(x=rm_x, y=rm_y)
         tx1, ty1 = config.get_target_one_coo()
@@ -113,10 +119,10 @@ def repeat_function(cargo_loading_time: float):
         )
         activate_eve_window()
         fe.drone_in()
-        fe.sleep_and_log(10)
+        fe.sleep_and_log(SMALL_SLEEP)
         auto_dock_to_station()
         # sleep long enough to be in station when program wakes up
-        fe.sleep_and_log(100)
+        fe.sleep_and_log(LONG_SLEEP)
         # docking will take some time, need to refocus window
         activate_eve_window()
         cg_x, cg_y = config.get_clear_cargo_coo()


### PR DESCRIPTION
fixes #57 

but all this direct access of config begs the question, why drill down the values at all?

- [x] remove config values drilling and access directly ?
- [ ] ~probably consider caching in config? but not a huge time sink to read each time...~
- [x] consider reintroduce a couple of constants?
- [x] consider adding randomness inside sleep_and_log? For ex between minimum 1s and maxium 2s. Just to add some variance. Eg. time.sleep(seconds + random.uniform(1,2)) or sumtin. Or maybe even 0s to 2s
- [ ] ~Consider adding the same randomness to mining_reset and mining_loop inside mining function (But dont pass in anything extra) EDIT: maybe not to mining_reset since thats important to keep in sync with miners. Actually nvm~