### PR TITLE
call external exe file to read eve memory export

### DIFF
--- a/Bot/bot.py
+++ b/Bot/bot.py
@@ -608,6 +608,7 @@ def repeat_function(cargo_loading_time: float) -> None:
         loaded_in_str = fe.get_remaining_time(cargo_loading_time)
         logger.info(f"The mining cargo is filled in about {loaded_in_str}")
         time.sleep(1)
+        mem = fe.adjust_display_positions(fe.read_eve_process_memory(str(window_pid)))
         undock_x, undock_y = fe.get_center_position(fe.find_undock_button(mem))
         fe.undock(x=undock_x, y=undock_y)
         fe.sleep_and_log(SMALL_SLEEP)

--- a/Bot/bot.py
+++ b/Bot/bot.py
@@ -637,7 +637,8 @@ def repeat_function(cargo_loading_time: float) -> None:
         activate_eve_window()
         fe.drone_in()
         fe.sleep_and_log(SMALL_SLEEP)
-        fe.auto_dock_to_station(config.get_home_coo())
+        home_x, home_y = fe.get_center_position(fe.find_bookmarks(mem)[0])
+        fe.auto_dock_to_station([home_x, home_y])
         # sleep long enough to be in station when program wakes up
         fe.sleep_and_log(LONG_SLEEP)
         # docking will take some time, need to refocus window

--- a/Bot/bot.py
+++ b/Bot/bot.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import random
 import re
 import sys
 import threading
@@ -591,24 +592,28 @@ def save_properties() -> None:
     config.save()
     logger.info("Configuration updated")
 
-
 def repeat_function(cargo_loading_time: float) -> None:
     disable_fields()
     actual_mining_runs = 0
     mining_runs = config.get_mining_runs()
     update_mining_runs(actual_mining_runs, mining_runs)
+    logger.info(f"Loading eve memory...")
+    window_pid = fe.get_pid_by_hwnd(selected_eve_window._hWnd) if selected_eve_window else None
+    logger.info(f"Selected window pid: {window_pid}")
+    mem = fe.adjust_display_positions(fe.read_eve_process_memory(str(window_pid)))
+    logger.info(f"Eve memory loaded! Starting mining...")
     while not stop_flag and actual_mining_runs < mining_runs:
         activate_eve_window()
         fe.set_next_reset(cargo_loading_time, fe.CARGO_LOAD_TIME)
         loaded_in_str = fe.get_remaining_time(cargo_loading_time)
         logger.info(f"The mining cargo is filled in about {loaded_in_str}")
         time.sleep(1)
-        undock_x, undock_y = config.get_undock_coo()
+        undock_x, undock_y = fe.get_center_position(fe.find_undock_button(mem))
         fe.undock(x=undock_x, y=undock_y)
         fe.sleep_and_log(SMALL_SLEEP)
         fe.set_hardener_online(config.get_hardener_keys())
-        item = fe.get_random_coord(config.get_mining_coo())
-        fe.click_top_left_circle_menu(item[0], item[1])
+        bookmark_x, bookmark_y = fe.get_center_position(random.choice(fe.find_bookmarks(mem)[1:]))
+        fe.click_top_left_circle_menu(bookmark_x, bookmark_y)
         fe.sleep_and_log(warping_time)
         activate_eve_window()
         rm_x, rm_y = config.get_mouse_reset_coo()

--- a/Bot/bot.py
+++ b/Bot/bot.py
@@ -618,8 +618,12 @@ def repeat_function(cargo_loading_time: float) -> None:
         activate_eve_window()
         rm_x, rm_y = config.get_mouse_reset_coo()
         fe.drone_out(x=rm_x, y=rm_y)
-        tx1, ty1 = config.get_target_one_coo()
-        tx2, ty2 = config.get_target_two_coo()
+        # read memory again to get the new positions
+        mem = fe.adjust_display_positions(fe.read_eve_process_memory(str(window_pid)))
+        asteroids = fe.find_asteroids(mem)
+        # TODO fail if less than two asteroids close enough
+        tx1, ty1 = asteroids[0][2]
+        tx2, ty2 = asteroids[1][2]
         fe.mining_behaviour(
             tx1=tx1,
             ty1=ty1,

--- a/Bot/functions.py
+++ b/Bot/functions.py
@@ -459,3 +459,34 @@ def find_bookmarks(json_obj):
             bookmarks.append(eve_label_medium)
 
     return bookmarks
+
+def calculate_center_position(json_obj):
+    """
+    Calculate the center position of a given object.
+
+    WARNING: This function should only be used for leaf nodes.
+
+    Parameters:
+    json_obj (dict): The JSON object to calculate the center position for.
+
+    Returns:
+    dict: The JSON object with the center position added.
+    """
+    json_obj = copy.deepcopy(json_obj)
+
+    data = json_obj.get('dictEntriesOfInterest', json_obj)
+
+    display_width = min(data.get('_displayWidth', 0), 100)
+    display_height = data.get('_displayHeight', 0)
+    display_x = data.get('_displayX', 0)
+    display_y = data.get('_displayY', 0)
+
+    if isinstance(display_width, dict):
+        display_width = display_width.get('int_low32', 0)
+    if isinstance(display_height, dict):
+        display_height = display_height.get('int_low32', 0)
+
+    data['_centerX'] = display_x + (display_width / 2)
+    data['_centerY'] = display_y + (display_height / 2)
+
+    return json_obj

--- a/Bot/functions.py
+++ b/Bot/functions.py
@@ -339,37 +339,68 @@ def write_to_file(str: str) -> None:
     f.write(str)
     f.close()
 
-def find_element_by_type(json_obj, object_type_name):
+def find_element_by_property(json_obj, property_name, property_value):
     """
-    Recursively searches through the JSON object to find the first element with the specified pythonObjectTypeName.
+    Recursively searches through the JSON object to find the first element with the specified property.
 
     Parameters:
     json_obj (dict or list): The JSON object to search through.
-    object_type_name (str): The value of 'pythonObjectTypeName' to search for.
+    property_name (str): The name of the property to search for.
+    property_value (str): The value of the property to search for.
 
     Returns:
-    dict or None: The JSON object corresponding to the specified pythonObjectTypeName or None if not found.
+    dict or None: The JSON object containing the specified property or None if not found.
     """
     if isinstance(json_obj, dict):
-        # Check if the current dictionary has the specified pythonObjectTypeName
-        if json_obj.get('pythonObjectTypeName') == object_type_name:
+        # Check if the current dictionary has the specified property
+        if json_obj.get(property_name) == property_value:
             return json_obj
         
         # Recursively search through each value in the dictionary
         for key, value in json_obj.items():
-            result = find_element_by_type(value, object_type_name)
+            result = find_element_by_property(value, property_name, property_value)
             if result is not None:
                 return result
 
     elif isinstance(json_obj, list):
         # Recursively search through each item in the list
         for item in json_obj:
-            result = find_element_by_type(item, object_type_name)
+            result = find_element_by_property(item, property_name, property_value)
             if result is not None:
                 return result
     
     # If no matching element is found, return None
     return None
+
+def find_elements_by_property(json_obj, property_name, property_value):
+    """
+    Recursively searches through the JSON object to find all elements with the specified property.
+
+    Parameters:
+    json_obj (dict or list): The JSON object to search through.
+    property_name (str): The name of the property to search for.
+    property_value (str): The value of the property to search for.
+
+    Returns:
+    list: A list of JSON objects containing the specified property.
+    """
+    results = []
+
+    if isinstance(json_obj, dict):
+        # Check if the current dictionary has the specified property
+        if json_obj.get(property_name) == property_value:
+            results.append(json_obj)
+        
+        # Recursively search through each value in the dictionary
+        for key, value in json_obj.items():
+            results.extend(find_elements_by_property(value, property_name, property_value))
+
+    elif isinstance(json_obj, list):
+        # Recursively search through each item in the list
+        for item in json_obj:
+            results.extend(find_elements_by_property(item, property_name, property_value))
+
+    return results
 
 def adjust_display_positions(json_obj, parent_display=None, is_top_level=True):
     if is_top_level:
@@ -409,3 +440,22 @@ def adjust_display_positions(json_obj, parent_display=None, is_top_level=True):
 
     if is_top_level:
         return json_obj
+
+def find_undock_button(json_obj):
+    # Find the LobbyWnd object
+    lobby_window = find_element_by_property(json_obj, 'pythonObjectTypeName', 'LobbyWnd')
+    # Find the first button with the text 'Undock'
+    return find_element_by_property(lobby_window, '_setText', 'Undock')
+
+def find_bookmarks(json_obj):
+    # Find all PlaceEntry objects
+    place_entries = find_elements_by_property(json_obj, 'pythonObjectTypeName', 'PlaceEntry')
+
+    bookmarks = []
+    # For each PlaceEntry, find the first EveLabelMedium
+    for place_entry in place_entries:
+        eve_label_medium = find_element_by_property(place_entry, 'pythonObjectTypeName', 'EveLabelMedium')
+        if eve_label_medium is not None:
+            bookmarks.append(eve_label_medium)
+
+    return bookmarks

--- a/Bot/functions.py
+++ b/Bot/functions.py
@@ -1,4 +1,5 @@
 import copy
+import ctypes
 import json
 import random
 import subprocess
@@ -284,6 +285,11 @@ def sleep_and_log(seconds: float) -> None:
 root_address: str = None
 current_pid: str = None
 
+def get_pid_by_hwnd(hwnd):
+    pid = ctypes.c_ulong()
+    ctypes.windll.user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
+    return pid.value
+
 def get_process_pid_by_name(process_name: str) -> str:
     """
     Retrieve a process PID by process name.
@@ -519,9 +525,9 @@ def find_bookmarks(json_obj):
 
     return bookmarks
 
-def calculate_center_position(json_obj):
+def get_center_position(json_obj):
     """
-    Calculate the center position of a given object.
+    Get the center position of a given object.
 
     WARNING: This function should only be used for leaf nodes.
 
@@ -547,7 +553,4 @@ def calculate_center_position(json_obj):
 
     display_width = min(display_width, 100)
 
-    data['_centerX'] = display_x + (display_width / 2)
-    data['_centerY'] = display_y + (display_height / 2)
-
-    return json_obj
+    return display_x + (display_width / 2), display_y + (display_height / 2)

--- a/Bot/functions.py
+++ b/Bot/functions.py
@@ -286,11 +286,18 @@ current_pid: str = None
 
 def get_process_pid_by_name(process_name: str) -> str:
     """
-    Retrieve a proccess pid by process name
+    Retrieve a process PID by process name.
 
-    :param process_name: The name of the process to search for.
-    :return: The pid or none
+    Parameters:
+    process_name (str): The name of the process to search for.
+
+    Returns:
+    str: The PID of the process.
+
+    Raises:
+    Exception: If the process is not found.
     """
+
     for proc in psutil.process_iter(['pid', 'name']):
         try:
             # Check if the process name matches
@@ -301,6 +308,20 @@ def get_process_pid_by_name(process_name: str) -> str:
     raise Exception("process " + process_name + " was not found")
 
 def read_eve_process_memory(pid: str | None  = None) -> dict:
+    """
+    Read the memory of the EVE Online process.
+
+    Parameters:
+    pid (str, optional): The PID of the process. If not provided, the function will attempt to find the PID of "exefile.exe".
+
+    Returns:
+    dict: A dictionary representing the memory of the EVE Online process.
+
+    Global Variables:
+    root_address (str): The root address of the EVE Online process memory.
+    current_pid (str): The current PID that the function is working with.
+    """
+    
     global root_address, current_pid
 
     pid = pid or get_process_pid_by_name("exefile.exe")
@@ -334,10 +355,16 @@ def read_eve_process_memory(pid: str | None  = None) -> dict:
     else:
         raise Exception(f"Error running the executable: {result.stderr}")
 
-def write_to_file(str: str) -> None:
-    f = open("demofile3.json", "w")
-    f.write(str)
-    f.close()
+def write_to_file(file: str, content: str) -> None:
+    """
+    Write a string to a file.
+
+    Parameters:
+    file (str): The path to the file.
+    content (str): The string to write to the file.
+    """
+    with open(file, "w") as f:
+        f.write(content)
 
 def find_element_by_property(json_obj, property_name, property_value):
     """
@@ -403,6 +430,18 @@ def find_elements_by_property(json_obj, property_name, property_value):
     return results
 
 def adjust_display_positions(json_obj, parent_display=None, is_top_level=True):
+    """
+    Adjust the display positions of a given JSON object.
+
+    Parameters:
+    json_obj (dict or list): The JSON object to adjust the display positions for.
+    parent_display (dict, optional): The display positions of the parent object.
+    is_top_level (bool, optional): Whether the JSON object is at the top level.
+
+    Returns:
+    dict or list: The JSON object with adjusted display positions.
+    """
+
     if is_top_level:
         json_obj = copy.deepcopy(json_obj)
 
@@ -442,12 +481,32 @@ def adjust_display_positions(json_obj, parent_display=None, is_top_level=True):
         return json_obj
 
 def find_undock_button(json_obj):
+    """
+    Find the undock button in a given JSON object.
+
+    Parameters:
+    json_obj (dict): The JSON object to find the undock button in.
+
+    Returns:
+    dict: The JSON object representing the undock button.
+    """
+
     # Find the LobbyWnd object
     lobby_window = find_element_by_property(json_obj, 'pythonObjectTypeName', 'LobbyWnd')
     # Find the first button with the text 'Undock'
     return find_element_by_property(lobby_window, '_setText', 'Undock')
 
 def find_bookmarks(json_obj):
+    """
+    Find all bookmarks in a given JSON object.
+
+    Parameters:
+    json_obj (dict): The JSON object to find the bookmarks in.
+
+    Returns:
+    list: A list of JSON objects representing the bookmarks.
+    """
+
     # Find all PlaceEntry objects
     place_entries = find_elements_by_property(json_obj, 'pythonObjectTypeName', 'PlaceEntry')
 

--- a/Bot/functions.py
+++ b/Bot/functions.py
@@ -476,7 +476,7 @@ def calculate_center_position(json_obj):
 
     data = json_obj.get('dictEntriesOfInterest', json_obj)
 
-    display_width = min(data.get('_displayWidth', 0), 100)
+    display_width = data.get('_displayWidth', 0)
     display_height = data.get('_displayHeight', 0)
     display_x = data.get('_displayX', 0)
     display_y = data.get('_displayY', 0)
@@ -485,6 +485,8 @@ def calculate_center_position(json_obj):
         display_width = display_width.get('int_low32', 0)
     if isinstance(display_height, dict):
         display_height = display_height.get('int_low32', 0)
+
+    display_width = min(display_width, 100)
 
     data['_centerX'] = display_x + (display_width / 2)
     data['_centerY'] = display_y + (display_height / 2)

--- a/Bot/functions.py
+++ b/Bot/functions.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import random
 import subprocess
@@ -370,7 +371,10 @@ def find_element_by_type(json_obj, object_type_name):
     # If no matching element is found, return None
     return None
 
-def adjust_display_positions(json_obj, parent_display=None):
+def adjust_display_positions(json_obj, parent_display=None, is_top_level=True):
+    if is_top_level:
+        json_obj = copy.deepcopy(json_obj)
+
     if parent_display is None:
         parent_display = {'_displayX': 0, '_displayY': 0}
 
@@ -397,8 +401,11 @@ def adjust_display_positions(json_obj, parent_display=None):
 
         if 'children' in json_obj and isinstance(json_obj['children'], list):
             for child in json_obj['children']:
-                adjust_display_positions(child, current_display)
+                adjust_display_positions(child, current_display, is_top_level=False)
 
     elif isinstance(json_obj, list):
         for item in json_obj:
-            adjust_display_positions(item, parent_display)
+            adjust_display_positions(item, parent_display, is_top_level=False)
+
+    if is_top_level:
+        return json_obj

--- a/README.md
+++ b/README.md
@@ -5,6 +5,24 @@ The Mining Bot Alpha Owl-Edition is a Python program developed to automate minin
 [![Video auf YouTube](https://img.youtube.com/vi/-qzjmKXXsqU/maxresdefault.jpg)](https://www.youtube.com/watch?v=-qzjmKXXsqU)
 [youtube link]
 
+## Sanderling exe
+
+Build standalone exe file for sanderling memory reading:
+
+`dotnet publish -c Release -r win-x64 --self-contained /p:PublishSingleFile=true`
+
+Run python interactive with functions.py
+
+`python -i .\Bot\functions.py`
+
+Run read_eve_process_memory function:
+
+`>>> read_eve_process_memory()["pythonObjectAddress"]`
+
+will take aprox 1 min
+
+Next should be faster, shy of a couple of seconds, beause root_address has been cached.
+
 ## Features
 
 - Automated mining in EVE Online

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Pillow
 pygetwindow
 loguru
 types-PyAutoGUI
+psutil


### PR DESCRIPTION
We can use this as a way to find elements to click, for ex undock button etc. Its all about finding a way to parse the json

- [x] uses a custom build of sanderling memory reading that returns json and doesnt store in a file
- [x] find a way to parse json where parent offsets (positions) must be added to child positions  (see sanderling alternative ui)
- [x] find a way to locate undock button and the bookmarks window
- [x] find a way to calculate an objects center position
- [x] find a way to find the two first options in the mining tab
- [ ] make it an option, to use memory reading, and not a requirement, to allow cross platform, maybe add a toggle to hide or show the input fields for locations ?
- [ ] hide the bot window, or make it alot smaller and change it from occupying right hand side to upper left hand side